### PR TITLE
Upgrade the mkdocs-material dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs-material>=9.5.10
+mkdocs-material>=9.6.3
 pymdown-extensions
 mkdocs-open-in-new-tab


### PR DESCRIPTION
The `mkdocs-material` dependency needs to be upgraded to a newer version to render the mermaid diagram submitted via https://github.com/dandi/dandi-docs/pull/176.

The [GitHub Action](https://github.com/mhausenblas/mkdocs-deploy-gh-pages) that we use to publish the pages uses a docker image that comes with `mkdocs-material` [at version 9.5.17](https://github.com/mhausenblas/mkdocs-deploy-gh-pages/blob/a31c6b13a80e4a4fbb525eeb7a2a78253bb15fa5/Dockerfile#L1C32-L1C38) to build the pages. Since, without the changes in this PR, `mkdocs-material` is constrained to `mkdocs-material>=9.5.10`, `mkdocs-material` at version 9.5.17 would be used to build the pages instead of the newer version needed to render the mermaid diagram correctly. Constraining the `mkdocs-material` dependency to the newer version in the `requirements.txt` file will allow a newer version of `mkdocs-material` in the build environment.
