### PR TITLE
Fix image links in the `system-architecture` page

### DIFF
--- a/docs/developer-guide/system-architecture.md
+++ b/docs/developer-guide/system-architecture.md
@@ -16,7 +16,7 @@ The DANDI platform is essentially composed of:
 These services interconnect as follows:
 
 <img
-src="../img/client_requests.jpg"
+src="../../img/client_requests.jpg"
 alt="client_requests"
 style="width: 90%; height: auto; display: block; margin-left: auto;  margin-right: auto;"/>
 
@@ -31,7 +31,7 @@ style="width: 90%; height: auto; display: block; margin-left: auto;  margin-righ
 ## Key Components
 
 <img
-src="../img/deployment.jpg"
+src="../../img/deployment.jpg"
 alt="dandi_deployment"
 style="width: 90%; height: auto; display: block; margin-left: auto;  margin-right: auto;"/>
 


### PR DESCRIPTION
The images don't currently resolve:

![image](https://github.com/user-attachments/assets/e61eb0d6-1f10-4f1c-a978-92e62ad35770)
