### PR TITLE
Fix download example commands

### DIFF
--- a/docs/user-guide-using/accessing-data/downloading.md
+++ b/docs/user-guide-using/accessing-data/downloading.md
@@ -48,13 +48,13 @@ Names of the subjects can be found on DANDI web application or by running a comm
 DANDI:000023`.
 Once you have the subject ID, you can download the data, e.g.:
 
-    dandi download https://api.dandiarchive.org/api/dandisets/000023/versions/draft/assets/?path=sub-811677083
+    dandi download "https://api.dandiarchive.org/api/dandisets/000023/versions/draft/assets/?path=sub-811677083"
 
 You could replace `draft` with a specific non-draft version you are interested in (e.g. `0.210914.1900` in the case of this Dandiset), if you are not interested in the latest, possibly different state of the Dandiset.
 
 You can also use the link from DANDI web application, e.g.:
 
-    dandi download https://dandiarchive.org/dandiset/000023/0.210914.1900/files?location=sub-541516760%2F
+    dandi download "https://dandiarchive.org/dandiset/000023/0.210914.1900/files?location=sub-541516760"
 
 
 ### Download a specific file from a Dandiset


### PR DESCRIPTION
Fix typo and add quotes since I am receiving the following error when there is a `=` or `?` symbol in the url.

```bash
% dandi download https://dandiarchive.org/dandiset/000023/0.210914.1900/files?location=sub-541516760

zsh: no matches found: https://dandiarchive.org/dandiset/000023/0.210914.1900/files?location=sub-541516760
```