### PR TITLE
Add GitHub Pages PR preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -1,0 +1,162 @@
+name: PR Documentation Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+      - '.github/workflows/pr-preview.yaml'
+
+permissions:
+  contents: write
+  pull-requests: write
+  pages: write
+  id-token: write
+
+jobs:
+  build-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install requirements
+        run: pip install -r requirements.txt
+
+      - name: Build documentation
+        run: mkdocs build --verbose
+
+      - name: Setup preview directory
+        run: |
+          mkdir -p pr-previews
+          cp -r site/* pr-previews/
+          echo "<html><head><meta http-equiv='refresh' content='0; url=pr-${{ github.event.number }}/'></head><body>Redirecting to PR preview...</body></html>" > pr-previews/index.html
+
+      - name: Deploy to GitHub Pages (PR Preview)
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          destination_dir: pr-${{ github.event.number }}
+          keep_files: true
+          enable_jekyll: false
+
+      - name: Comment PR with preview link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const repoName = context.repo.repo;
+            const repoOwner = context.repo.owner;
+            const previewUrl = `https://${repoOwner}.github.io/${repoName}/pr-${prNumber}/`;
+            
+            // Check if we already commented
+            const comments = await github.rest.issues.listComments({
+              owner: repoOwner,
+              repo: repoName,
+              issue_number: prNumber
+            });
+            
+            const botComment = comments.data.find(comment => 
+              comment.user.login === 'github-actions[bot]' && 
+              comment.body.includes('📖 Documentation Preview')
+            );
+            
+            const commentBody = `## 📖 Documentation Preview
+            
+            The documentation for this PR has been built and is available for preview:
+            
+            🔗 **[View PR Preview](${previewUrl})**
+            
+            This preview will be updated automatically when you push changes to this PR.
+            
+            ---
+            *Preview generated from commit: ${context.sha.substring(0, 7)}*`;
+            
+            if (botComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: repoOwner,
+                repo: repoName,
+                comment_id: botComment.id,
+                body: commentBody
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: repoOwner,
+                repo: repoName,
+                issue_number: prNumber,
+                body: commentBody
+              });
+            }
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Remove PR preview directory
+        run: |
+          if [ -d "pr-${{ github.event.number }}" ]; then
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            rm -rf pr-${{ github.event.number }}
+            git add .
+            git commit -m "Clean up PR #${{ github.event.number }} preview" || exit 0
+            git push
+          fi
+
+      - name: Comment PR cleanup
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const repoName = context.repo.repo;
+            const repoOwner = context.repo.owner;
+            
+            // Find and update the bot comment
+            const comments = await github.rest.issues.listComments({
+              owner: repoOwner,
+              repo: repoName,
+              issue_number: prNumber
+            });
+            
+            const botComment = comments.data.find(comment => 
+              comment.user.login === 'github-actions[bot]' && 
+              comment.body.includes('📖 Documentation Preview')
+            );
+            
+            if (botComment) {
+              const updatedBody = botComment.body + '\n\n**✅ Preview cleaned up** - PR has been closed/merged.';
+              await github.rest.issues.updateComment({
+                owner: repoOwner,
+                repo: repoName,
+                comment_id: botComment.id,
+                body: updatedBody
+              });
+            }


### PR DESCRIPTION
- Creates PR-specific subdirectories for documentation previews
- Automatically comments on PRs with preview links
- Cleans up previews when PRs are closed
- Uses GitHub Pages instead of external services